### PR TITLE
Update streamit-mlb-image.bb

### DIFF
--- a/recipes-streamit/images/streamit-mlb-image.bb
+++ b/recipes-streamit/images/streamit-mlb-image.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Streamit MLB base image"
 
 require recipes-rk/images/rk-image-multimedia.bb
 
-#GPTIMG_APPEND = "console=tty1 console=ttyS2,115200n8 rw root=/dev/mmcblk0p7 rootfstype=ext4 init=/sbin/init"
+GPTIMG_APPEND = "console=tty1 console=ttyS2,115200n8 rw root=/dev/mmcblk0p7 rootfstype=ext4 init=/sbin/init"
 
 CORE_IMAGE_EXTRA_INSTALL += " \
 	openssh \


### PR DESCRIPTION
The 'default' image is for a bootable SD card, which requires rootfs parameter mmcblk0p7