### PR TITLE
Split up image types

### DIFF
--- a/classes/streamit-mlb-emmc-img.bbclass
+++ b/classes/streamit-mlb-emmc-img.bbclass
@@ -1,0 +1,18 @@
+inherit image_types streamit-mlb-img
+IMAGE_TYPEDEP_streamit-mlb-emmc-img = "streamit-mlb-img"
+
+EMMCIMG = "${IMAGE_BASENAME}-${MACHINE}-emmc.img"
+
+IMAGE_CMD_streamit-mlb-emmc-img () {
+	# Change to image directory
+	cd ${DEPLOY_DIR_IMAGE}
+
+	# Remove the existing image
+	rm -f "${EMMCIMG}"
+
+	# Burn Boot Partition
+	dd if=${WORKDIR}/${EMMC_BOOT_IMG} of=${EMMCIMG} conv=notrunc,fsync
+
+	# Burn Rootfs Partition
+	dd if=${IMG_ROOTFS} of=${EMMCIMG} conv=notrunc,fsync seek=${BOOT_SIZE}
+}

--- a/classes/streamit-mlb-gpt-img.bbclass
+++ b/classes/streamit-mlb-gpt-img.bbclass
@@ -1,0 +1,85 @@
+inherit image_types streamit-mlb-img
+IMAGE_TYPEDEP_streamit-mlb-gpt-img = "streamit-mlb-img"
+
+GPTIMG = "${IMAGE_BASENAME}-${MACHINE}-gpt.img"
+
+IMAGE_CMD_streamit-mlb-gpt-img () {
+	# Change to image directory
+	cd ${DEPLOY_DIR_IMAGE}
+
+	# Remove the existing image
+	rm -f "${GPTIMG}"
+
+	# last dd rootfs will extend gpt image to fit the size,
+	# but this will overrite the backup table of GPT
+	# will cause corruption error for GPT
+	IMG_ROOTFS_SIZE=$(stat -L --format="%s" ${IMG_ROOTFS})
+
+    echo "ROOTFS SIZE: ${IMG_ROOTFS_SIZE}"
+    echo "LOADER1_SIZE: ${LOADER1_SIZE}"
+
+	GPTIMG_MIN_SIZE=$(expr $IMG_ROOTFS_SIZE + \( ${LOADER1_SIZE} + ${RESERVED1_SIZE} + ${RESERVED2_SIZE} + ${LOADER2_SIZE} + ${ATF_SIZE} + ${BOOT_SIZE} + 35 \) \* 512 )
+
+    echo "FIRST EXPR DONE"
+	GPT_IMAGE_SIZE=$(expr $GPTIMG_MIN_SIZE \/ 1024 \/ 1024 + 2)
+
+    echo "SECOND EXPR DONE"
+
+	# Initialize sdcard image file
+	dd if=/dev/zero of=${GPTIMG} bs=1M count=0 seek=$GPT_IMAGE_SIZE
+
+	# Create partition table
+	parted -s ${GPTIMG} mklabel gpt
+
+	# Create vendor defined partitions
+	LOADER1_START=64
+	RESERVED1_START=$(expr ${LOADER1_START} + ${LOADER1_SIZE})
+	RESERVED2_START=$(expr ${RESERVED1_START} + ${RESERVED1_SIZE})
+	LOADER2_START=$(expr ${RESERVED2_START} + ${RESERVED2_SIZE})
+	ATF_START=$(expr ${LOADER2_START} + ${LOADER2_SIZE})
+	BOOT_START=$(expr ${ATF_START} + ${ATF_SIZE})
+	ROOTFS_START=$(expr ${BOOT_START} + ${BOOT_SIZE})
+
+	parted -s ${GPTIMG} unit s mkpart loader1 ${LOADER1_START} $(expr ${RESERVED1_START} - 1)
+	# parted -s ${GPTIMG} unit s mkpart reserved1 ${RESERVED1_START} $(expr ${RESERVED2_START} - 1)
+	# parted -s ${GPTIMG} unit s mkpart reserved2 ${RESERVED2_START} $(expr ${LOADER2_START} - 1)
+	parted -s ${GPTIMG} unit s mkpart loader2 ${LOADER2_START} $(expr ${ATF_START} - 1)
+	parted -s ${GPTIMG} unit s mkpart trust ${ATF_START} $(expr ${BOOT_START} - 1)
+
+	# Create boot partition and mark it as bootable
+	parted -s ${GPTIMG} unit s mkpart boot ${BOOT_START} $(expr ${ROOTFS_START} - 1)
+	parted -s ${GPTIMG} set 4 boot on
+
+	# Create rootfs partition
+	parted -s ${GPTIMG} -- unit s mkpart rootfs ${ROOTFS_START} -34s
+
+	parted ${GPTIMG} print
+
+	if [ "${DEFAULTTUNE}" = "aarch64" ];then
+		ROOT_UUID="B921B045-1DF0-41C3-AF44-4C6F280D3FAE"
+	else
+		ROOT_UUID="69DAD710-2CE4-4E3C-B16C-21A1D49ABED3"
+	fi
+
+	# Change rootfs partuuid
+	gdisk ${GPTIMG} <<EOF
+x
+c
+5
+${ROOT_UUID}
+w
+y
+EOF
+
+	# Burn bootloader
+	mkimage -n ${SOC_FAMILY} -T rksd -d ${DEPLOY_DIR_IMAGE}/${SPL_BINARY} ${WORKDIR}/${IDBLOADER}
+	cat ${DEPLOY_DIR_IMAGE}/u-boot-${MACHINE}.bin >>${WORKDIR}/${IDBLOADER}
+	dd if=${WORKDIR}/${IDBLOADER} of=${GPTIMG} conv=notrunc,fsync seek=64
+
+	# Burn Boot Partition
+	dd if=${WORKDIR}/${EMMC_BOOT_IMG} of=${GPTIMG} conv=notrunc,fsync seek=${BOOT_START}
+
+	# Burn Rootfs Partition
+	dd if=${IMG_ROOTFS} of=${GPTIMG} conv=notrunc,fsync seek=${ROOTFS_START}
+
+}

--- a/classes/streamit-mlb-img.bbclass
+++ b/classes/streamit-mlb-img.bbclass
@@ -1,0 +1,109 @@
+# Copyright (C) 2017 Fuzhou Rockchip Electronics Co., Ltd
+# Copyright (C) 2017 Trevor Woerner <twoerner@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+# Use an uncompressed ext4 by default as rootfs
+IMG_ROOTFS_TYPE = "ext4"
+IMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.${IMG_ROOTFS_TYPE}"
+
+# This image depends on the rootfs image
+IMAGE_TYPEDEP_streamit-mlb-img = "${IMG_ROOTFS_TYPE}"
+
+EMMC_BOOT_IMG = "${IMAGE_BASENAME}-${MACHINE}-emmc-boot.img"
+SD_BOOT_IMG = "${IMAGE_BASENAME}-${MACHINE}-sd-boot.img"
+EMMC_GPTIMG_APPEND ??= "console=tty1 console=ttyS2,115200n8 rw \
+	root=/dev/mmcblk2p5 rootfstype=ext4 init=/sbin/init"
+SD_GPTIMG_APPEND ??= "console=tty1 console=ttyS2,115200n8 rw \
+	root=/dev/mmcblk0p2 rootfstype=ext4 init=/sbin/init"
+
+IDBLOADER = "idbloader.img"
+
+# Get From rk-binary loader
+DDR_BIN = "ddr.bin"
+LOADER_BIN = "loader.bin"
+MINILOADER_BIN = "miniloader.bin"
+ATF_BIN = "atf.bin"
+UBOOT_IMG = "u-boot.img"
+TRUST_IMG = "trust.img"
+
+# default partitions [in Sectors]
+# More info at http://rockchip.wikidot.com/partitions
+LOADER1_SIZE = "8000"
+RESERVED1_SIZE = "128"
+RESERVED2_SIZE = "8192"
+LOADER2_SIZE = "8192"
+ATF_SIZE = "8192"
+BOOT_SIZE = "229376"
+
+# WORKROUND: miss recipeinfo
+do_image_streamit_mlb_img[depends] += " \
+	rk-binary-loader:do_populate_lic \
+	virtual/bootloader:do_populate_lic"
+
+do_image_streamit_mlb_img[depends] += " \
+	parted-native:do_populate_sysroot \
+	u-boot-mkimage-native:do_populate_sysroot \
+	mtools-native:do_populate_sysroot \
+	gptfdisk-native:do_populate_sysroot \
+	dosfstools-native:do_populate_sysroot \
+	rk-binary-native:do_populate_sysroot \
+	rk-binary-loader:do_deploy \
+	virtual/kernel:do_deploy \
+	virtual/bootloader:do_deploy"
+
+PER_CHIP_IMG_GENERATION_COMMAND_rk3036 = "generate_loader1_image"
+PER_CHIP_IMG_GENERATION_COMMAND_rk3288 = "generate_loader1_image"
+PER_CHIP_IMG_GENERATION_COMMAND_rk3328 = "generate_aarch64_loader_image"
+PER_CHIP_IMG_GENERATION_COMMAND_rk3399 = "generate_aarch64_loader_image"
+
+IMAGE_CMD_streamit-mlb-img () {
+	# Change to image directory
+	cd ${DEPLOY_DIR_IMAGE}
+
+    create_boot_image "${EMMC_BOOT_IMG}" "${EMMC_GPTIMG_APPEND}"
+    create_boot_image "${SD_BOOT_IMG}" "${SD_GPTIMG_APPEND}"
+}
+
+create_boot_image () {
+    BOOT_IMG="$1";
+    GPTIMG_APPEND="$2";
+    echo "BOOT IMG: ${BOOT_IMG}"
+    echo "GPT APPEND: ${GPTIMG_APPEND}"
+    rm -f "${BOOT_IMG}"
+    rm -f "${WORKDIR}/${BOOT_IMG}"
+	# Create boot partition image
+	BOOT_BLOCKS=114688
+
+	mkfs.vfat -n "boot" -S 512 -C ${WORKDIR}/${BOOT_IMG} $BOOT_BLOCKS
+	mcopy -i ${WORKDIR}/${BOOT_IMG} -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${MACHINE}.bin ::${KERNEL_IMAGETYPE}
+
+	DTS_FILE=""
+	DTBPATTERN="${KERNEL_IMAGETYPE}((-\w+)+\.dtb)"
+	for DFILES in ${DEPLOY_DIR_IMAGE}/*; do
+		DFILES=${DFILES##*/}
+		if echo "${DFILES}" | grep -P $DTBPATTERN ; then
+			[ -n "${DTS_FILE}" ] && bberror "Found multiple DTB under deploy dir, Please delete the unnecessary one."
+			DTS_FILE=${DFILES#*${KERNEL_IMAGETYPE}-}
+		fi
+	done
+
+	mcopy -i ${WORKDIR}/${BOOT_IMG} -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${DTS_FILE} ::${DTS_FILE}
+
+	# Create extlinux config file
+	cat >${WORKDIR}/extlinux.conf <<EOF
+default yocto
+
+label yocto
+	kernel /${KERNEL_IMAGETYPE}
+	devicetree /${DTS_FILE}
+	append ${GPTIMG_APPEND}
+EOF
+
+	mmd -i ${WORKDIR}/${BOOT_IMG} ::/extlinux
+	mcopy -i ${WORKDIR}/${BOOT_IMG} -s ${WORKDIR}/extlinux.conf ::/extlinux/
+
+	cd ${DEPLOY_DIR_IMAGE}
+	if [ -f ${WORKDIR}/${BOOT_IMG} ]; then
+		cp ${WORKDIR}/${BOOT_IMG} ./
+	fi
+}

--- a/classes/streamit-mlb-sd-img.bbclass
+++ b/classes/streamit-mlb-sd-img.bbclass
@@ -1,0 +1,46 @@
+inherit image_types streamit-mlb-img
+IMAGE_TYPEDEP_streamit-mlb-sd-img = "streamit-mlb-img"
+
+SDIMG = "${IMAGE_BASENAME}-${MACHINE}-sd.img"
+
+IMAGE_CMD_streamit-mlb-sd-img () {
+	# Change to image directory
+	cd ${DEPLOY_DIR_IMAGE}
+
+	# Remove the existing image
+	rm -f "${SDIMG}"
+
+	# last dd rootfs will extend gpt image to fit the size,
+	# but this will overrite the backup table of GPT
+	# will cause corruption error for GPT
+	IMG_ROOTFS_SIZE=$(stat -L --format="%s" ${IMG_ROOTFS})
+
+	SDIMG_MIN_SIZE=$(expr $IMG_ROOTFS_SIZE + \( ${BOOT_SIZE} + 35 \) \* 512 )
+
+	SD_IMAGE_SIZE=$(expr $SDIMG_MIN_SIZE \/ 1024 \/ 1024 + 2)
+
+	# Initialize sdcard image file
+	dd if=/dev/zero of=${SDIMG} bs=1M count=0 seek=$SD_IMAGE_SIZE
+
+	# Create partition table
+	parted -s ${SDIMG} mklabel gpt
+
+	# Create vendor defined partitions
+	BOOT_START=64
+	ROOTFS_START=$(expr ${BOOT_START} + ${BOOT_SIZE})
+
+	# Create boot partition and mark it as bootable
+	parted -s ${SDIMG} unit s mkpart boot ${BOOT_START} $(expr ${ROOTFS_START} - 1)
+	parted -s ${SDIMG} set 1 boot on
+
+	# Create rootfs partition
+	parted -s ${SDIMG} -- unit s mkpart rootfs ${ROOTFS_START} -34s
+
+	parted ${SDIMG} print
+
+	# Burn Boot Partition
+	dd if=${WORKDIR}/${SD_BOOT_IMG} of=${SDIMG} conv=notrunc,fsync seek=${BOOT_START}
+
+	# Burn Rootfs Partition
+	dd if=${IMG_ROOTFS} of=${SDIMG} conv=notrunc,fsync seek=${ROOTFS_START}
+}

--- a/conf/machine/streamit-mlb400.conf
+++ b/conf/machine/streamit-mlb400.conf
@@ -6,11 +6,25 @@
 #@DESCRIPTION: Streamits DSP
 #http://www.streamit.eu/
 
-include conf/machine/include/rk3288.inc
+SOC_FAMILY = "rk3288"
 
+require conf/machine/include/tune-cortexa17.inc
+require conf/machine/include/soc-family.inc
+
+MACHINEOVERRIDES =. "mali-gpu:mali-midgard:"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-rockchip"
 PREFERRED_VERSION_linux-rockchip = "4.4%"
+
+SERIAL_CONSOLES = "115200;ttyS2"
+KERNEL_IMAGETYPE = "zImage"
+KBUILD_DEFCONFIG = "rockchip_linux_defconfig"
+
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-rockchip"
+SPL_BINARY ?= "u-boot-spl-dtb.bin"
+
+IMAGE_FSTYPES += "streamit-mlb-emmc-img"
+IMAGE_CLASSES += "streamit-mlb-img streamit-mlb-gpt-img streamit-mlb-emmc-img streamit-mlb-sd-img"
 
 KERNEL_DEVICETREE = "rk3288-streamit-mlb400.dtb"
 UBOOT_MACHINE = "streamit-mlb400-rk3288_defconfig"
-
-KBUILD_DEFCONFIG = "rockchip_linux_defconfig"

--- a/recipes-streamit/images/streamit-mlb-image.bb
+++ b/recipes-streamit/images/streamit-mlb-image.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Streamit MLB base image"
 
 require recipes-rk/images/rk-image-multimedia.bb
 
-GPTIMG_APPEND = "console=tty1 console=ttyS2,115200n8 rw root=/dev/mmcblk0p7 rootfstype=ext4 init=/sbin/init"
+IMAGE_FSTYPES += " streamit-mlb-gpt-img streamit-mlb-sd-img" 
 
 CORE_IMAGE_EXTRA_INSTALL += " \
 	openssh \


### PR DESCRIPTION
This pull request ensures three different types of images can be built, depending on configuration. The default rockchip image generation code has been significantly modified to do this.